### PR TITLE
Fix msgp stateproof unit tests

### DIFF
--- a/tests/cucumber/unit.tags
+++ b/tests/cucumber/unit.tags
@@ -19,6 +19,7 @@
 @unit.sourcemap
 @unit.stateproof.paths
 @unit.stateproof.responses
+@unit.stateproof.responses.msgp
 @unit.tealsign
 @unit.transactions
 @unit.transactions.keyreg


### PR DESCRIPTION
Make the `@unit.stateproof.responses.msgp` tests work.

The underlying problem was that binary data (i.e. Buffers or Uint8Arrays) cannot be used for cucumber step arguments, since these arguments are transmitted to the browser using JSON. I've added a check which will fail early if this ever happens again.

